### PR TITLE
Reset stats when returning home

### DIFF
--- a/rps_controller_version10.py
+++ b/rps_controller_version10.py
@@ -364,6 +364,12 @@ class RPSApp:
 
     # -------------- Navigation --------------
     def goto(self, name):
+        if name == "screen1":
+            self.player_history = {"wins": 0, "losses": 0, "draws": 0, "rounds": 0}
+            self.player_moves.clear()
+            self.last_player_move = None
+            self.predictor = MarkovPredictor()
+
         self.current_screen = name
         random_gradient(self.screen_bg)
         if name == "screen3":
@@ -470,10 +476,6 @@ class RPSApp:
                     self.goto("screen3")  # keep history
                 elif self.btn_no.collidepoint(pos):
                     self.popup_active = False
-                    self.player_history = {"wins": 0, "losses": 0, "draws": 0, "rounds": 0}
-                    self.player_moves.clear()
-                    self.last_player_move = None
-                    self.predictor = MarkovPredictor()  # reset model
                     self.goto("screen1")
             else:
                 if self.btn_playagain.collidepoint(pos):


### PR DESCRIPTION
## Summary
- Reset player history, move history, and predictive model whenever navigating back to the home screen so wins/losses/draws/rounds start fresh.

## Testing
- `python -m py_compile rps_controller_version10.py`
- `python rps_controller_version10.py --help` *(fails: ModuleNotFoundError: No module named 'pygame')*


------
https://chatgpt.com/codex/tasks/task_e_68b17de5232c832e9897aadd3258cc2d