### PR TITLE
Center Back button label

### DIFF
--- a/rps_controller_version10.py
+++ b/rps_controller_version10.py
@@ -505,8 +505,9 @@ class RPSApp:
         hovered = self.btn_back.collidepoint(mx,my)
         pygame.draw.rect(self.screen, (240,240,240) if hovered else (220,220,220), self.btn_back, border_radius=12)
         pygame.draw.rect(self.screen, (80,80,80), self.btn_back, width=2, border_radius=12)
-        back_label = self.font_small.render("← Back", True, (30,30,30))
-        self.screen.blit(back_label, (self.btn_back.x + 16, self.btn_back.y + 10))
+        back_label = self.font_small.render("Back", True, (30,30,30))
+        back_rect = back_label.get_rect(center=self.btn_back.center)
+        self.screen.blit(back_label, back_rect)
 
         # HUD
         g = self.cam.get_gesture()


### PR DESCRIPTION
## Summary
- remove arrow character from Back button
- center Back label within button for consistent alignment

## Testing
- `python -m py_compile rps_controller_version10.py rps_controller_version4_shared.py`


------
https://chatgpt.com/codex/tasks/task_e_68b185d15130832ea2c2e59b13915a22